### PR TITLE
Skip addNode() in ClusterManager init() if no nodeConfig passed.

### DIFF
--- a/ClusterManager.cfc
+++ b/ClusterManager.cfc
@@ -32,6 +32,8 @@ component accessors="true"{
 			}
 		}else if(isArray(arguments.nodeConfig)){
 			config = arguments.nodeConfig;
+		} else {
+			return this;
 		}
 
 		for(var c=1; c<=arrayLen(config); c++){


### PR DESCRIPTION
Hi. When I tried to run `ClusterManager = new ClusterManager()` as in your ReadMe example, I got an error about `config` not being an array. Seems the function `loadConfigFromString` couldn't handle the default empty string. This fixes that.
