### PR TITLE
CF9 compatibility fixes

### DIFF
--- a/ElasticSearchClient.cfc
+++ b/ElasticSearchClient.cfc
@@ -30,19 +30,19 @@ component accessors="true" extends="Base" {
 	}
 
 	public IndexRequest function prepareIndex(string index="", string type="", string id=""){
-		var index = new requests.IndexRequest(ClusterManager=getClusterManager());
-			index.setIndex(arguments.index);
-			index.setType(arguments.type);
-			index.setId(arguments.id);
-		return index;
+		var ix = new requests.IndexRequest(ClusterManager=getClusterManager());
+			ix.setIndex(arguments.index);
+			ix.setType(arguments.type);
+			ix.setId(arguments.id);
+		return ix;
 	}
 	
 	public MappingRequest function prepareMapping(required string index, required string type, required elasticsearch.indexing.TypeMapping typeMapping){
-		var index = new requests.MappingRequest(ClusterManager=getClusterManager());
-			index.setIndex(arguments.index);
-			index.setType(arguments.type);
-			index.setBody(typeMapping.getJson());
-		return index;
+		var ix = new requests.MappingRequest(ClusterManager=getClusterManager());
+			ix.setIndex(arguments.index);
+			ix.setType(arguments.type);
+			ix.setBody(arguments.typeMapping.getJson());
+		return ix;
 	}
 
 	public BulkRequest function prepareBulk(boolean Transactional=false){

--- a/requests/GetRequest.cfc
+++ b/requests/GetRequest.cfc
@@ -12,15 +12,15 @@ component accessors="true" {
 	property name="ClusterManager" type="ClusterManager";
 
 	public GetRequest function init(required ClusterManager ClusterManager){
-		variables.ClusterManager = arguments.ClusterManager
+		variables.ClusterManager = arguments.ClusterManager;
 		return this;
 	}
 
 	public GetResponse function execute(){
 		var _url = "/#getIndex()#/#getType()#/#getId()#";
 
-		if(getSourceOnly()){
-			_url = _url & "/_source"
+		if(NOT isNull(getSourceOnly())){
+			_url = _url & "/_source";
 		}
 
 		_url = _url & "?realtime=#getRealtime()#";

--- a/responses/GetResponse.cfc
+++ b/responses/GetResponse.cfc
@@ -31,6 +31,7 @@ component extends="Response" accessors="true" implements="IResponse" {
 				setExists(getBody()["exists"]);
 			}
 		if(getSuccess()){
+			setExists(true); // default does not work in CF9
 			if(structKeyExists(getBody(), "_source")){
 				setSource(getBody()["_source"]);
 			}

--- a/responses/IResponse.cfc
+++ b/responses/IResponse.cfc
@@ -1,3 +1,3 @@
 interface{
-	public void function handleResponse(){}
+	public void function handleResponse();
 }

--- a/responses/Response.cfc
+++ b/responses/Response.cfc
@@ -14,11 +14,18 @@ component accessors="true" implements="IResponse"{
 	public void function handleResponse(){
 
 		var _httpResponse = arguments[1];
-		
-		setStatusCode(_httpResponse.status_code);
-		setStatus(_httpResponse.StatusCode);
-		setBody(deserializeJSON(_httpResponse.FileContent));
+
+		local.content = _httpResponse.FileContent;
+
+		if(getMetaData(local.content).getName() IS "java.io.ByteArrayOutputStream") {
+			local.content = _httpResponse.FileContent.toString();
+		}
+
+		setStatusCode(_httpResponse.Responseheader.Status_Code);
+		setStatus(_httpResponse.Responseheader.Explanation);
+		setBody(deserializeJSON(local.content));
 		setHeaders(_httpResponse.responseHeader);
+		setSuccess(false); // default does not work in CF9
 
 		if(getStatusCode() <= 206 && getStatusCode() >= 200){
 			setSuccess(true);


### PR DESCRIPTION
Several compatibility fixes for ColdFusion 9:
1. index in arguments and local (var) scope threw an error so renamed var index to var ix
2. typeMapping.getJson() was throwing an error without being scoped
3. GetRequest constructor was throwing an error due to missing semi-colon
4. getSourceOnly() was returning undefined and was throwing an error so changed to NOT isNull
5. _url setter inside if getSourceOnly was throwing an error due to missing semi-colon
6. GetResponse exists property default is not being recognized. CF9 sees it as undefined.
7. IResponse was throwing an error saying that the interface cannot have a body
8. http response fixes in Response
9. Response success property default is not being recognized. CF9 sees it as undefined.
10. deserializeJSON(_httpResponse.FileContent fails when _httpResponse.FileContent is java.io.ByteArrayOutputStream
